### PR TITLE
dco3 version bump to 0.10.2 and dccmd-rs to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "dccmd-rs"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-recursion",
  "chrono",
@@ -554,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "dco3"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ddf6700bb58a0ab69fb781cabf38490fa3a08deac383a4e7871b0401c95ead9"
+checksum = "0cf20b87cc3a94fece8f77d2e37ab2b55c23ec3525fadf206f12548d4c4555d6"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dccmd-rs"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "A command line client for DRACOON"
 authors = ["Octavio Simone"]
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 # DRACOON API
-dco3 = "0.10"
+dco3 = "0.10.2"
 
 # CLI helpers
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
Bump dco3 to version 0.10.2 to address the serialization issue of 'mfa_enforced' as camelCase by @unbekanntes-pferd in https://github.com/unbekanntes-pferd/dco3/pull/23. This change resolves the issue preventing user import from functioning correctly.