### PR TITLE
chore: refactor params, bump version to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "dccmd-rs"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-recursion",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dccmd-rs"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "A command line client for DRACOON"
 authors = ["Octavio Simone"]

--- a/src/cmd/users/mod.rs
+++ b/src/cmd/users/mod.rs
@@ -197,7 +197,7 @@ impl UserCommandHandler {
             let reqs = (500..=total)
                 .step_by(500)
                 .map(|offset| {
-                    let params = self.build_params(&search, offset.into(), 500);
+                    let params = self.build_params(&search, offset, 500);
                     self.client.users.get_users(Some(params), None, None)
                 })
                 .collect::<Vec<_>>();


### PR DESCRIPTION
- refactor build_params
- bump version to 0.3.1 for new build with new dependencies (`dco3`)