### PR TITLE
feat(upload): add flag for preserving share links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "dccmd-rs"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-recursion",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dccmd-rs"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "A command line client for DRACOON"
 authors = ["Octavio Simone"]

--- a/src/cmd/models.rs
+++ b/src/cmd/models.rs
@@ -107,6 +107,10 @@ pub enum DcCmdCommand {
         #[clap(long)]
         overwrite: bool,
 
+        /// Preserve Download Share Links and point them to the new node in DRACOON
+        #[clap(long)]
+        keep_share_links: bool,
+
         /// classification of the node (1-4)
         #[clap(long)]
         classification: Option<u8>,

--- a/src/cmd/nodes/models.rs
+++ b/src/cmd/nodes/models.rs
@@ -54,6 +54,7 @@ impl CmdDownloadOptions {
 #[allow(clippy::struct_excessive_bools)]
 pub struct CmdUploadOptions {
     pub overwrite: bool,
+    pub keep_share_links: bool,
     pub recursive: bool,
     pub skip_root: bool,
     pub share: bool,
@@ -68,6 +69,7 @@ pub struct CmdUploadOptions {
 impl CmdUploadOptions {
     pub fn new(
         overwrite: bool,
+        keep_share_links: bool,
         recursive: bool,
         skip_root: bool,
         share: bool,
@@ -79,6 +81,7 @@ impl CmdUploadOptions {
     ) -> Self {
         Self {
             overwrite,
+            keep_share_links,
             recursive,
             skip_root,
             share,

--- a/src/cmd/nodes/upload.rs
+++ b/src/cmd/nodes/upload.rs
@@ -481,6 +481,7 @@ async fn upload_container(
         target,
         file_map,
         opts.overwrite,
+        opts.keep_share_links,
         opts.classification,
         opts.velocity,
     )
@@ -636,6 +637,7 @@ async fn upload_files(
     parent_node: &Node,
     files: BTreeMap<PathBuf, (u64, u64)>,
     overwrite: bool,
+    keep_share_links: bool,
     classification: Option<u8>,
     velocity: Option<u8>,
 ) -> Result<(), DcCmdError> {
@@ -688,8 +690,6 @@ async fn upload_files(
                 } else {
                     ResolutionStrategy::AutoRename
                 };
-
-                let keep_share_links = matches!(resolution_strategy, ResolutionStrategy::Overwrite);
 
                 let upload_options = UploadOptions::builder(file_meta)
                     .with_classification(classification)

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,7 @@ async fn main() {
             source,
             target,
             overwrite,
+            keep_share_links,
             classification,
             velocity,
             recursive,
@@ -73,6 +74,7 @@ async fn main() {
                 target,
                 CmdUploadOptions::new(
                     overwrite,
+                    keep_share_links,
                     recursive,
                     skip_root,
                     share,


### PR DESCRIPTION
The current implementation for retaining share links restricts flexibility. 
It would be helpful to be able to specify whether existing share links should be preserved, regardless of the conflict resolution method. 